### PR TITLE
Fix walkthrough scenario

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -146,6 +146,12 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/mattbaird/jsonpatch"
+  packages = ["."]
+  revision = "81af80346b1a01caae0cbc27fd3c1ba5b11e189f"
+
+[[projects]]
   name = "github.com/modern-go/concurrent"
   packages = ["."]
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
@@ -377,6 +383,7 @@
 [[projects]]
   name = "k8s.io/api"
   packages = [
+    "admission/v1beta1",
     "admissionregistration/v1alpha1",
     "admissionregistration/v1beta1",
     "apps/v1",
@@ -413,7 +420,10 @@
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
-    "pkg/apis/apiextensions/v1beta1"
+    "pkg/apis/apiextensions/v1beta1",
+    "pkg/client/clientset/clientset",
+    "pkg/client/clientset/clientset/scheme",
+    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
   ]
   revision = "4347b330d0ff094db860f2f75fa725b4f4b53618"
   version = "kubernetes-1.10.1"
@@ -569,6 +579,7 @@
     "pkg/client/apiutil",
     "pkg/client/config",
     "pkg/controller",
+    "pkg/envtest",
     "pkg/event",
     "pkg/handler",
     "pkg/internal/controller",
@@ -579,6 +590,7 @@
     "pkg/recorder",
     "pkg/runtime/inject",
     "pkg/runtime/log",
+    "pkg/runtime/scheme",
     "pkg/runtime/signals",
     "pkg/source",
     "pkg/source/internal"
@@ -610,6 +622,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "bfdfdcd42937389241e9c76decc23658d29e0916f3e9fa2c6e4fac3bbd648ff5"
+  inputs-digest = "7b57c452ca3a14c50ca9326f6146c0ea7acbb580aca286cd871fb24053e97158"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ generate:
 docker-build: test
 	docker build . -t ${IMG}
 	@echo "updating kustomize image patch file for manager resource"
-	sed -i 's@image: .*@image: '"${IMG}"'@' ./config/default/manager_image_patch.yaml
+	sed -i '' -e 's@image: .*@image: '"${IMG}"'@' ./config/default/manager_image_patch.yaml
 
 # Push the docker image
 docker-push:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,8 +18,9 @@ namePrefix: podpreset-crd-
 # YAML string, with resources separated by document
 # markers ("---").
 resources:
-- ../rbac/*.yaml
-- ../manager/*.yaml
+- ../rbac/rbac_role.yaml
+- ../rbac/rbac_role_binding.yaml
+- ../manager/manager.yaml
 
 patches:
 - manager_image_patch.yaml

--- a/vendor/github.com/mattbaird/jsonpatch/.gitignore
+++ b/vendor/github.com/mattbaird/jsonpatch/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/mattbaird/jsonpatch/LICENSE
+++ b/vendor/github.com/mattbaird/jsonpatch/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/mattbaird/jsonpatch/README.md
+++ b/vendor/github.com/mattbaird/jsonpatch/README.md
@@ -1,0 +1,46 @@
+# jsonpatch
+As per http://jsonpatch.com/ JSON Patch is specified in RFC 6902 from the IETF.
+
+JSON Patch allows you to generate JSON that describes changes you want to make to a document, so you don't have to send the whole doc. JSON Patch format is supported by HTTP PATCH method, allowing for standards based partial updates via REST APIs.
+
+```bash
+go get github.com/mattbaird/jsonpatch
+```
+
+I tried some of the other "jsonpatch" go implementations, but none of them could diff two json documents and 
+generate format like jsonpatch.com specifies. Here's an example of the patch format:
+
+```json
+[
+  { "op": "replace", "path": "/baz", "value": "boo" },
+  { "op": "add", "path": "/hello", "value": ["world"] },
+  { "op": "remove", "path": "/foo"}
+]
+
+```
+The API is super simple
+#example
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/mattbaird/jsonpatch"
+)
+
+var simpleA = `{"a":100, "b":200, "c":"hello"}`
+var simpleB = `{"a":100, "b":200, "c":"goodbye"}`
+
+func main() {
+	patch, e := jsonpatch.CreatePatch([]byte(simpleA), []byte(simpleA))
+	if e != nil {
+		fmt.Printf("Error creating JSON patch:%v", e)
+		return
+	}
+	for _, operation := range patch {
+		fmt.Printf("%s\n", operation.Json())
+	}
+}
+```
+
+This code needs more tests, as it's a highly recursive, type-fiddly monster. It's not a lot of code, but it has to deal with a lot of complexity.

--- a/vendor/github.com/mattbaird/jsonpatch/jsonpatch.go
+++ b/vendor/github.com/mattbaird/jsonpatch/jsonpatch.go
@@ -1,0 +1,257 @@
+package jsonpatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+var errBadJSONDoc = fmt.Errorf("Invalid JSON Document")
+
+type JsonPatchOperation struct {
+	Operation string      `json:"op"`
+	Path      string      `json:"path"`
+	Value     interface{} `json:"value,omitempty"`
+}
+
+func (j *JsonPatchOperation) Json() string {
+	b, _ := json.Marshal(j)
+	return string(b)
+}
+
+func (j *JsonPatchOperation) MarshalJSON() ([]byte, error) {
+	var b bytes.Buffer
+	b.WriteString("{")
+	b.WriteString(fmt.Sprintf(`"op":"%s"`, j.Operation))
+	b.WriteString(fmt.Sprintf(`,"path":"%s"`, j.Path))
+	// Consider omitting Value for non-nullable operations.
+	if j.Value != nil || j.Operation == "replace" || j.Operation == "add" {
+		v, err := json.Marshal(j.Value)
+		if err != nil {
+			return nil, err
+		}
+		b.WriteString(`,"value":`)
+		b.Write(v)
+	}
+	b.WriteString("}")
+	return b.Bytes(), nil
+}
+
+type ByPath []JsonPatchOperation
+
+func (a ByPath) Len() int           { return len(a) }
+func (a ByPath) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByPath) Less(i, j int) bool { return a[i].Path < a[j].Path }
+
+func NewPatch(operation, path string, value interface{}) JsonPatchOperation {
+	return JsonPatchOperation{Operation: operation, Path: path, Value: value}
+}
+
+// CreatePatch creates a patch as specified in http://jsonpatch.com/
+//
+// 'a' is original, 'b' is the modified document. Both are to be given as json encoded content.
+// The function will return an array of JsonPatchOperations
+//
+// An error will be returned if any of the two documents are invalid.
+func CreatePatch(a, b []byte) ([]JsonPatchOperation, error) {
+	aI := map[string]interface{}{}
+	bI := map[string]interface{}{}
+	err := json.Unmarshal(a, &aI)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+	err = json.Unmarshal(b, &bI)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+	return diff(aI, bI, "", []JsonPatchOperation{})
+}
+
+// Returns true if the values matches (must be json types)
+// The types of the values must match, otherwise it will always return false
+// If two map[string]interface{} are given, all elements must match.
+func matchesValue(av, bv interface{}) bool {
+	if reflect.TypeOf(av) != reflect.TypeOf(bv) {
+		return false
+	}
+	switch at := av.(type) {
+	case string:
+		bt := bv.(string)
+		if bt == at {
+			return true
+		}
+	case float64:
+		bt := bv.(float64)
+		if bt == at {
+			return true
+		}
+	case bool:
+		bt := bv.(bool)
+		if bt == at {
+			return true
+		}
+	case map[string]interface{}:
+		bt := bv.(map[string]interface{})
+		for key := range at {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		for key := range bt {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		return true
+	case []interface{}:
+		bt := bv.([]interface{})
+		if len(bt) != len(at) {
+			return false
+		}
+		for key := range at {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		for key := range bt {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// From http://tools.ietf.org/html/rfc6901#section-4 :
+//
+// Evaluation of each reference token begins by decoding any escaped
+// character sequence.  This is performed by first transforming any
+// occurrence of the sequence '~1' to '/', and then transforming any
+// occurrence of the sequence '~0' to '~'.
+//   TODO decode support:
+//   var rfc6901Decoder = strings.NewReplacer("~1", "/", "~0", "~")
+
+var rfc6901Encoder = strings.NewReplacer("~", "~0", "/", "~1")
+
+func makePath(path string, newPart interface{}) string {
+	key := rfc6901Encoder.Replace(fmt.Sprintf("%v", newPart))
+	if path == "" {
+		return "/" + key
+	}
+	if strings.HasSuffix(path, "/") {
+		return path + key
+	}
+	return path + "/" + key
+}
+
+// diff returns the (recursive) difference between a and b as an array of JsonPatchOperations.
+func diff(a, b map[string]interface{}, path string, patch []JsonPatchOperation) ([]JsonPatchOperation, error) {
+	for key, bv := range b {
+		p := makePath(path, key)
+		av, ok := a[key]
+		// value was added
+		if !ok {
+			patch = append(patch, NewPatch("add", p, bv))
+			continue
+		}
+		// If types have changed, replace completely
+		if reflect.TypeOf(av) != reflect.TypeOf(bv) {
+			patch = append(patch, NewPatch("replace", p, bv))
+			continue
+		}
+		// Types are the same, compare values
+		var err error
+		patch, err = handleValues(av, bv, p, patch)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Now add all deleted values as nil
+	for key := range a {
+		_, found := b[key]
+		if !found {
+			p := makePath(path, key)
+
+			patch = append(patch, NewPatch("remove", p, nil))
+		}
+	}
+	return patch, nil
+}
+
+func handleValues(av, bv interface{}, p string, patch []JsonPatchOperation) ([]JsonPatchOperation, error) {
+	var err error
+	switch at := av.(type) {
+	case map[string]interface{}:
+		bt := bv.(map[string]interface{})
+		patch, err = diff(at, bt, p, patch)
+		if err != nil {
+			return nil, err
+		}
+	case string, float64, bool:
+		if !matchesValue(av, bv) {
+			patch = append(patch, NewPatch("replace", p, bv))
+		}
+	case []interface{}:
+		bt, ok := bv.([]interface{})
+		if !ok {
+			// array replaced by non-array
+			patch = append(patch, NewPatch("replace", p, bv))
+		} else if len(at) != len(bt) {
+			// arrays are not the same length
+			patch = append(patch, compareArray(at, bt, p)...)
+
+		} else {
+			for i := range bt {
+				patch, err = handleValues(at[i], bt[i], makePath(p, i), patch)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	case nil:
+		switch bv.(type) {
+		case nil:
+			// Both nil, fine.
+		default:
+			patch = append(patch, NewPatch("add", p, bv))
+		}
+	default:
+		panic(fmt.Sprintf("Unknown type:%T ", av))
+	}
+	return patch, nil
+}
+
+func compareArray(av, bv []interface{}, p string) []JsonPatchOperation {
+	retval := []JsonPatchOperation{}
+	//	var err error
+	for i, v := range av {
+		found := false
+		for _, v2 := range bv {
+			if reflect.DeepEqual(v, v2) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			retval = append(retval, NewPatch("remove", makePath(p, i), nil))
+		}
+	}
+
+	for i, v := range bv {
+		found := false
+		for _, v2 := range av {
+			if reflect.DeepEqual(v, v2) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			retval = append(retval, NewPatch("add", makePath(p, i), v))
+		}
+	}
+
+	return retval
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

_Fix minor bugs in the walkthrough scenario by:_

- fixing resources path declarations in kustomization.yaml file (regex in file names is not supported, see: https://github.com/kubernetes-sigs/kustomize/issues/254) 
**previous error:** 
```
kustomize build config/default | kubectl apply -f -
Error: loadResMapFromBasesAndResources: rawResources failed to read Resources: Load from path ../rbac/*.yaml failed: open /Users/i331808/workspace/go/src/github.com/jpeeler/podpreset-crd/config/rbac/*.yaml: no such file or directory
```
  - fixing missing dependencies in vendor
**previous error:** 
```
make docker-build-webhook

CGO_ENABLED=0 GOOS=linux go build -o ./webhook/webhook ./webhook/
webhook/main.go:31:2: cannot find package "github.com/mattbaird/jsonpatch" in any of:
	/Users/i331808/workspace/go/src/github.com/jpeeler/podpreset-crd/vendor/github.com/mattbaird/jsonpatch (vendor tree)
	/usr/local/Cellar/go/1.10.2/libexec/src/github.com/mattbaird/jsonpatch (from $GOROOT)
	/Users/i331808/workspace/go/src/github.com/mattbaird/jsonpatch (from $GOPATH)
make: *** [docker-build-webhook] Error 1
````
  - fixing sed command to works also on OS X system
**previous error:** 
```
updating kustomize image patch file for manager resource
sed -i 's@image: .*@image: '"docker.io/service-catalog/podpreset-controller:latest"'@' ./config/default/manager_image_patch.yaml
sed: 1: "./config/default/manage ...": invalid command code .
make: *** [docker-build] Error 1
```
